### PR TITLE
Fix: index.js not executing when template folder and config name mismatch

### DIFF
--- a/bin/project-wizard.js
+++ b/bin/project-wizard.js
@@ -92,8 +92,6 @@ async function main() {
 
   const logicPath = path.join(chosen.path, "index.js");
 
-  console.log(logicPath);
-
   if (chosen.templateDeps?.length) {
     const deps = chosen.templateDeps.join(" ");
     console.log(`+ Installing template runtime deps: ${deps}`);

--- a/bin/project-wizard.js
+++ b/bin/project-wizard.js
@@ -90,10 +90,9 @@ async function main() {
   )
     initGitRepo(dest);
 
-  const logicPath = path.join(
-    path.join(__dirname, `../templates/${chosen.name}`),
-    "index.js",
-  );
+  const logicPath = path.join(chosen.path, "index.js");
+
+  console.log(logicPath);
 
   if (chosen.templateDeps?.length) {
     const deps = chosen.templateDeps.join(" ");


### PR DESCRIPTION
Fixed a bug where index.js was not executed if the template's folder name and the name field in config.json did not match.